### PR TITLE
watchex: use correct licence

### DIFF
--- a/bucket/watchex.json
+++ b/bucket/watchex.json
@@ -2,7 +2,7 @@
     "version": "1.0.2",
     "description": "watchex",
     "homepage": "https://github.com/francWhite/watchex",
-    "license": "GPL3",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/francWhite/watchex/releases/download/v1.0.2/watchex-v1.0.2-win-x64.zip",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
